### PR TITLE
feature/get-letter : 편지 조회 로직 구현

### DIFF
--- a/src/main/java/com/teosprint/chudam/controller/LetterController.java
+++ b/src/main/java/com/teosprint/chudam/controller/LetterController.java
@@ -1,7 +1,12 @@
 package com.teosprint.chudam.controller;
 
+import com.teosprint.chudam.dto.LetterInfoResponseDto;
 import com.teosprint.chudam.service.LetterService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class LetterController {
 
     private final LetterService letterService;
+
+    // 편지 조회
+    @GetMapping("/api/letter/{letterId}")
+    public ResponseEntity<LetterInfoResponseDto> getLetter(@PathVariable Long letterId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(letterService.getLetter(letterId));
+    }
 }

--- a/src/main/java/com/teosprint/chudam/dto/LetterInfoResponseDto.java
+++ b/src/main/java/com/teosprint/chudam/dto/LetterInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.teosprint.chudam.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LetterInfoResponseDto {
+
+    private String letterImageUrl;
+
+    public static LetterInfoResponseDto from(String letterImageUrl) {
+        return LetterInfoResponseDto.builder()
+                .letterImageUrl(letterImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/teosprint/chudam/service/LetterService.java
+++ b/src/main/java/com/teosprint/chudam/service/LetterService.java
@@ -1,5 +1,10 @@
 package com.teosprint.chudam.service;
 
 
+import com.teosprint.chudam.dto.LetterInfoResponseDto;
+
 public interface LetterService {
+
+    // 편지 조회
+    LetterInfoResponseDto getLetter(Long letterId);
 }

--- a/src/main/java/com/teosprint/chudam/service/LetterServiceImpl.java
+++ b/src/main/java/com/teosprint/chudam/service/LetterServiceImpl.java
@@ -1,5 +1,8 @@
 package com.teosprint.chudam.service;
 
+import com.teosprint.chudam.domain.Letter;
+import com.teosprint.chudam.dto.LetterInfoResponseDto;
+import com.teosprint.chudam.exception.custom.LetterCustomException;
 import com.teosprint.chudam.repository.LetterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,4 +12,13 @@ import org.springframework.stereotype.Service;
 public class LetterServiceImpl implements LetterService {
 
     private final LetterRepository letterRepository;
+
+    @Override
+    public LetterInfoResponseDto getLetter(Long letterId) {
+        Letter letter = letterRepository.findById(letterId)
+                .orElseThrow(() -> LetterCustomException.DOES_NOT_EXIST_LETTER);
+
+        LetterInfoResponseDto letterInfoResponse = LetterInfoResponseDto.from(letter.getLetterImageUrl());
+        return letterInfoResponse;
+    }
 }


### PR DESCRIPTION
## 📌 요약(Summary)
- 편지 조회 구현

<br>

## ✏️ 상세 내용(Describe your changes)
- 편지 조회 요청 시 응답할 LetterInfoResponseDto 생성했습니다.
- /api/letter/{letterId} 엔드포인트로 요청하고 조회 요청 성공 시 200 OK 상태코드를, 실패 시 404 상태코드를 응답하도록 구현했습니다.

<br>

## 🚀 연관 이슈(Issue Number or Link)
- #9  `Letter 조회 기능`
