### PR TITLE
fix/create-letter : 편지 저장 로직 수정

### DIFF
--- a/src/main/java/com/teosprint/chudam/dto/CreateLetterRequestDto.java
+++ b/src/main/java/com/teosprint/chudam/dto/CreateLetterRequestDto.java
@@ -10,5 +10,5 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 public class CreateLetterRequestDto {
 
-    private MultipartFile letterImage;
+    private String letterImage;
 }

--- a/src/main/java/com/teosprint/chudam/service/LetterServiceImpl.java
+++ b/src/main/java/com/teosprint/chudam/service/LetterServiceImpl.java
@@ -10,8 +10,10 @@ import com.teosprint.chudam.exception.custom.LetterCustomException;
 import com.teosprint.chudam.exception.errorcode.AwsS3ErrorCode;
 import com.teosprint.chudam.exception.errorcode.LetterErrorCode;
 import com.teosprint.chudam.repository.LetterRepository;
+import com.teosprint.chudam.util.Base64Utils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -37,7 +39,8 @@ public class LetterServiceImpl implements LetterService {
     @Override
     public CreateLetterResponseDto createLetter(CreateLetterRequestDto createLetterRequest) {
         try{
-            MultipartFile multipartFile = createLetterRequest.getLetterImage();
+            MultipartFile multipartFile = Base64Utils.convertBase64ToMultipartFile(createLetterRequest.getLetterImage());
+
             if(multipartFile != null){
                 AwsS3FileResponseDto response = awsS3Service.uploadFile(multipartFile);
                 Letter letter = letterRepository.save(Letter.createLetter(response.getUrl(), LocalDateTime.now()));

--- a/src/main/java/com/teosprint/chudam/util/Base64Utils.java
+++ b/src/main/java/com/teosprint/chudam/util/Base64Utils.java
@@ -1,0 +1,74 @@
+package com.teosprint.chudam.util;
+
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+
+public class Base64Utils {
+    public static MultipartFile convertBase64ToMultipartFile(String base64String) {
+        try {
+            // base64 문자열을 디코드하여 바이너리 데이터로 변환
+            byte[] decodedBytes = Base64.decodeBase64(base64String);
+
+            // 디코드된 바이너리 데이터를 MultipartFile 객체로 변환
+            MultipartFile multipartFile = new Base64DecodedMultipartFile(decodedBytes);
+
+            return multipartFile;
+        } catch (Exception e) {
+            // 디코딩 과정에서 오류가 발생할 경우 예외 처리
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    // 디코드된 바이너리 데이터를 사용하여 MultipartFile 객체를 생성하는 클래스
+    private static class Base64DecodedMultipartFile implements MultipartFile {
+
+        private final byte[] content;
+
+        public Base64DecodedMultipartFile(byte[] content) {
+            this.content = content;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return null;
+        }
+
+        @Override
+        public String getContentType() {
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return content == null || content.length == 0;
+        }
+
+        @Override
+        public long getSize() {
+            return content.length;
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return content;
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return new ByteArrayInputStream(content);
+        }
+
+        @Override
+        public void transferTo(File dest) throws IOException, IllegalStateException {
+            new FileOutputStream(dest).write(content);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 요약(Summary)
- 편지 작성 로직 수정

<br>

## ✏️ 상세 내용(Describe your changes)
- 기존 클라이언트에서 인코딩된 파일을 Base64로 디코드된 파일을 요청하는 방법에서 인코딩된 파일 문자열을 서버로 요청하고 서버에서 Base64로 디코드하고 편지 이미지를 저장 하도록 수정했습니다.

<br>

## 🚀 연관 이슈(Issue Number or Link)
- 
